### PR TITLE
enhance: use string & {} for better auto completion [HEP-44]

### DIFF
--- a/src/style/component/flex.css.ts
+++ b/src/style/component/flex.css.ts
@@ -4,14 +4,14 @@ export const displayVariants = styleVariants({
   flex: { display: "flex" },
 });
 
-export type Display = keyof typeof displayVariants | string;
+export type Display = keyof typeof displayVariants | (string & {});
 
 export const flexDirectionVariants = styleVariants({
   row: { flexDirection: "row" },
   col: { flexDirection: "column" },
 });
 
-export type FlexDirection = keyof typeof flexDirectionVariants | string;
+export type FlexDirection = keyof typeof flexDirectionVariants | (string & {});
 
 export const justifyVariants = styleVariants({
   start: { justifyContent: "flex-start" },
@@ -19,7 +19,7 @@ export const justifyVariants = styleVariants({
   end: { justifyContent: "flex-end" },
 });
 
-export type JustifyContent = keyof typeof justifyVariants | string;
+export type JustifyContent = keyof typeof justifyVariants | (string & {});
 
 export const alignVariants = styleVariants({
   start: { alignItems: "flex-start" },
@@ -27,7 +27,7 @@ export const alignVariants = styleVariants({
   end: { justifyContent: "flex-end" },
 });
 
-export type AlignItems = keyof typeof alignVariants | string;
+export type AlignItems = keyof typeof alignVariants | (string & {});
 
 export const flexWrapVariants = styleVariants({
   none: { flexWrap: "nowrap" },
@@ -35,25 +35,25 @@ export const flexWrapVariants = styleVariants({
   reverse: { flexWrap: "wrap-reverse" },
 });
 
-export type Wrap = keyof typeof flexWrapVariants | string;
+export type Wrap = keyof typeof flexWrapVariants | (string & {});
 
 export const gapVariants = styleVariants({
   none: { gap: "0" },
   md: { gap: "1rem" },
 });
 
-export type Gap = keyof typeof gapVariants | string;
+export type Gap = keyof typeof gapVariants | (string & {});
 
 export const columnGapVariants = styleVariants({
   none: { columnGap: "0" },
   md: { columnGap: "1rem" },
 });
 
-export type ColumnGap = keyof typeof columnGapVariants | string;
+export type ColumnGap = keyof typeof columnGapVariants | (string & {});
 
 export const rowGapVariants = styleVariants({
   none: { rowGap: "0" },
   md: { rowGap: "1rem" },
 });
 
-export type RowGap = keyof typeof rowGapVariants | string;
+export type RowGap = keyof typeof rowGapVariants | (string & {});

--- a/src/style/shared/dimension.css.ts
+++ b/src/style/shared/dimension.css.ts
@@ -10,5 +10,5 @@ export const heightVariants = styleVariants({
   screen: { height: "vh" },
 });
 
-export type Width = keyof typeof widthVariants | string;
-export type Height = keyof typeof heightVariants | string;
+export type Width = keyof typeof widthVariants | (string & {});
+export type Height = keyof typeof heightVariants | (string & {});


### PR DESCRIPTION
By using `SomeType | (string & {})` instead of `SomeType | string`, we can get better auto completion suggestions.